### PR TITLE
Increased module compatibility to PHP =< 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"issues": "http://github.com/tractorcow/silverstripe-dynamiccache/issues"
 	},
 	"require": {
-		"php": "~5.4",
+		"php": ">= 5.4, <7.2",
 		"silverstripe/framework": "3.*",
 		"silverstripe/cms": "3.*",
 		"composer/installers": "*"


### PR DESCRIPTION
The composer restriction in this module was making it hard to run this module with Silverstripe 3.6 now that SS is PHP 7 compatible. This PR should resolve that issue.